### PR TITLE
+Edgeware support. +Reload network on network selection.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:app/app.dart';
 import 'package:flutter/material.dart';
 import 'package:polkawallet_plugin_acala/polkawallet_plugin_acala.dart';
 import 'package:polkawallet_plugin_kusama/polkawallet_plugin_kusama.dart';
+import 'package:polkawallet_plugin_edgeware/polkawallet_plugin_edgeware.dart';
 
 import 'package:get_storage/get_storage.dart';
 import 'package:polkawallet_plugin_laminar/polkawallet_plugin_laminar.dart';
@@ -14,6 +15,7 @@ void main() async {
     PluginKusama(),
     PluginAcala(),
     PluginLaminar(),
+    PluginEdgeware(),
   ];
 
   runApp(WalletApp(_plugins));

--- a/lib/pages/assets/asset/assetPage.dart
+++ b/lib/pages/assets/asset/assetPage.dart
@@ -190,9 +190,8 @@ class _AssetPageState extends State<AssetPage>
   }
 
   List<Widget> _buildTxList() {
-    final isKSMOrDOT = widget.service.plugin.basic.name == 'kusama' ||
-        widget.service.plugin.basic.name == 'polkadot';
-    final symbol = isKSMOrDOT
+    final isList = widget.service.plugin.networkState.tokenSymbol is List;
+    final symbol = isList
         ? widget.service.plugin.networkState.tokenSymbol[0]
         : widget.service.plugin.networkState.tokenSymbol ?? '';
     final txs = widget.service.store.assets.txs.toList();
@@ -233,12 +232,11 @@ class _AssetPageState extends State<AssetPage>
       Tab(text: dic['out']),
     ];
 
-    final isKSMOrDOT = widget.service.plugin.basic.name == 'kusama' ||
-        widget.service.plugin.basic.name == 'polkadot';
-    final symbol = isKSMOrDOT
+    final isList = widget.service.plugin.networkState.tokenSymbol is List;
+    final symbol = isList
         ? widget.service.plugin.networkState.tokenSymbol[0]
         : widget.service.plugin.networkState.tokenSymbol ?? '';
-    final decimals = isKSMOrDOT
+    final decimals = isList
         ? widget.service.plugin.networkState.tokenDecimals[0]
         : widget.service.plugin.networkState.tokenDecimals ?? 12;
 

--- a/lib/pages/assets/index.dart
+++ b/lib/pages/assets/index.dart
@@ -223,12 +223,11 @@ class _AssetsState extends State<AssetsPage> {
   Widget build(BuildContext context) {
     return Observer(
       builder: (_) {
-        final isKSMOrDOT = widget.service.plugin.basic.name == 'kusama' ||
-            widget.service.plugin.basic.name == 'polkadot';
-        final symbol = isKSMOrDOT
+        final isList = widget.service.plugin.networkState.tokenSymbol is List;
+        final symbol = isList
             ? (widget.service.plugin.networkState.tokenSymbol ?? [''])[0]
             : widget.service.plugin.networkState.tokenSymbol ?? '';
-        final decimals = isKSMOrDOT
+        final decimals = isList
             ? (widget.service.plugin.networkState.tokenDecimals ?? [12])[0]
             : widget.service.plugin.networkState.tokenDecimals ?? 12;
 

--- a/lib/pages/assets/transfer/detailPage.dart
+++ b/lib/pages/assets/transfer/detailPage.dart
@@ -17,12 +17,11 @@ class TransferDetailPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final Map<String, String> dic =
         I18n.of(context).getDic(i18n_full_dic_app, 'assets');
-    final isKSMOrDOT = service.plugin.basic.name == 'kusama' ||
-        service.plugin.basic.name == 'polkadot';
-    final symbol = isKSMOrDOT
+    final isList = service.plugin.networkState.tokenSymbol is List;
+    final symbol = isList
         ? service.plugin.networkState.tokenSymbol[0]
         : service.plugin.networkState.tokenSymbol ?? '';
-    final decimals = isKSMOrDOT
+    final decimals = isList
         ? service.plugin.networkState.tokenDecimals[0]
         : service.plugin.networkState.tokenDecimals ?? 12;
 

--- a/lib/pages/assets/transfer/transferPage.dart
+++ b/lib/pages/assets/transfer/transferPage.dart
@@ -63,12 +63,11 @@ class _TransferPageState extends State<TransferPage> {
   Future<TxConfirmParams> _getTxParams() async {
     if (_formKey.currentState.validate()) {
       final dic = I18n.of(context).getDic(i18n_full_dic_app, 'assets');
-      final isKSMOrDOT = widget.service.plugin.basic.name == 'kusama' ||
-          widget.service.plugin.basic.name == 'polkadot';
-      final symbol = isKSMOrDOT
+      final isList = widget.service.plugin.networkState.tokenSymbol is List;
+      final symbol = isList
           ? widget.service.plugin.networkState.tokenSymbol[0]
           : widget.service.plugin.networkState.tokenSymbol ?? '';
-      final decimals = isKSMOrDOT
+      final decimals = isList
           ? widget.service.plugin.networkState.tokenDecimals[0]
           : widget.service.plugin.networkState.tokenDecimals ?? 12;
       return TxConfirmParams(
@@ -138,12 +137,11 @@ class _TransferPageState extends State<TransferPage> {
     return Observer(
       builder: (_) {
         final dic = I18n.of(context).getDic(i18n_full_dic_app, 'assets');
-        final isKSMOrDOT = widget.service.plugin.basic.name == 'kusama' ||
-            widget.service.plugin.basic.name == 'polkadot';
-        final symbol = isKSMOrDOT
+        final isList = widget.service.plugin.networkState.tokenSymbol is List;
+        final symbol = isList
             ? widget.service.plugin.networkState.tokenSymbol[0]
             : widget.service.plugin.networkState.tokenSymbol ?? '';
-        final decimals = isKSMOrDOT
+        final decimals = isList
             ? widget.service.plugin.networkState.tokenDecimals[0]
             : widget.service.plugin.networkState.tokenDecimals ?? 12;
 

--- a/lib/pages/networkSelectPage.dart
+++ b/lib/pages/networkSelectPage.dart
@@ -202,6 +202,7 @@ class _NetworkSelectPageState extends State<NetworkSelectPage> {
                             if (!isCurrent) {
                               setState(() {
                                 _selectedNetwork = i;
+                                _reloadNetwork();
                               });
                             }
                           },

--- a/lib/pages/profile/recovery/recoverySettingPage.dart
+++ b/lib/pages/profile/recovery/recoverySettingPage.dart
@@ -163,12 +163,12 @@ class _RecoverySettingPage extends State<RecoverySettingPage> {
       body: SafeArea(
         child: Observer(
           builder: (_) {
-            final isKSMOrDOT = widget.service.plugin.basic.name == 'kusama' ||
-                widget.service.plugin.basic.name == 'polkadot';
-            final symbol = isKSMOrDOT
+            final isList =
+                widget.service.plugin.networkState.tokenSymbol is List;
+            final symbol = isList
                 ? widget.service.plugin.networkState.tokenSymbol[0]
                 : widget.service.plugin.networkState.tokenSymbol ?? '';
-            final decimals = isKSMOrDOT
+            final decimals = isList
                 ? widget.service.plugin.networkState.tokenDecimals[0]
                 : widget.service.plugin.networkState.tokenDecimals ?? 12;
 

--- a/lib/pages/profile/recovery/txDetailPage.dart
+++ b/lib/pages/profile/recovery/txDetailPage.dart
@@ -19,12 +19,11 @@ class TxDetailPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final dicStaking = I18n.of(context).getDic(i18n_full_dic_kusama, 'staking');
-    final isKSMOrDOT =
-        plugin.basic.name == 'kusama' || plugin.basic.name == 'polkadot';
-    final symbol = isKSMOrDOT
+    final isList = plugin.networkState.tokenSymbol is List;
+    final symbol = isList
         ? plugin.networkState.tokenSymbol[0]
         : plugin.networkState.tokenSymbol ?? '';
-    final decimals = isKSMOrDOT
+    final decimals = isList
         ? plugin.networkState.tokenDecimals[0]
         : plugin.networkState.tokenDecimals ?? 12;
     final TxData detail = ModalRoute.of(context).settings.arguments;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -606,6 +606,15 @@ packages:
       url: "https://github.com/AcalaNetwork/polkawallet_plugin_acala.git"
     source: git
     version: "0.0.1"
+  polkawallet_plugin_edgeware:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: fb505d0df92d9a29b80569a080302da0ddf82f16
+      resolved-ref: fb505d0df92d9a29b80569a080302da0ddf82f16
+      url: "https://github.com/remzrn/polkawallet_plugin_edgeware.git"
+    source: git
+    version: "0.0.1"
   polkawallet_plugin_kusama:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,11 @@ dependencies:
       url: https://github.com/polkawallet-io/polkawallet_plugin_laminar.git
       ref: c11d572fc55257c2bb28a75d6620155a771010b4
 #    path: ../../coding/polkawallet/polkawallet_plugin_laminar
+  polkawallet_plugin_edgeware:
+    git:
+      url: https://github.com/remzrn/polkawallet_plugin_edgeware.git
+      ref: fb505d0df92d9a29b80569a080302da0ddf82f16
+#    path: ../../coding/polkawallet/polkawallet_plugin_edgeware
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
This adds support for Edgeware following [the previous discussion](https://github.com/polkawallet-io/polkawallet-flutter/pull/205).
The new separation makes it much cleaner to add functionalities, yet there is still need for a few amendments in the app repo (this PR) and to the [SDK one](https://github.com/polkawallet-io/sdk/pull/2). Probably the SDK version needs to be bumped accordingly in the pubspec file if those are merged. With the current SDK version, Edgeware would not work.
The changes are:
+ Addition of a specific polkawallet_plugin_edgeware mostly copied from Kusama, with a few adaptations specific to the chain. This is linking [a public repo on my own account](https://github.com/remzrn/polkawallet_plugin_edgeware) that you may want to host and redirect if you want everything to be self-contained.
+ Modified specific handling of token symbols and decimals for polkadot and kusama so that it takes into account every chain that need an additional degree of indirection. Edgeware works this way too.
+ Reload the network on network selection change rather than account change. [This change](https://github.com/polkawallet-io/app/compare/master...remzrn:master#diff-fc2d715feb316ab94db2aafe55710ab0aa54826fd95c2ebb2fdd413c67b41813R205) is not functionally required, but I found it a bit better in terms of UX to have the theming and address format changed without having to select an account. This is particularly useful for people who use a single mnemonic to generate accounts for different chains, since they don't need to select a different account every time.

Note that unfortunately, I am not able to test the ios builds. I tested on Android only.